### PR TITLE
feat: _id explicit false value on mongoose

### DIFF
--- a/lib/service-specs-to-mongoose.js
+++ b/lib/service-specs-to-mongoose.js
@@ -63,7 +63,11 @@ function serviceSpecsToMongoose (feathersSpec, feathersExtension, depth = 1) {
   let items;
 
   Object.keys(properties).forEach(name => {
-    if (discardFields.indexOf(name) !== -1) return;
+    if (
+      discardFields.indexOf(name) !== -1
+      && !(name === '_id' && properties[name] === false)
+    )
+      return;
 
     const property = properties[name];
     let type = property.type;
@@ -84,7 +88,14 @@ function serviceSpecsToMongoose (feathersSpec, feathersExtension, depth = 1) {
         {
           type = 'date';
         }
-        mongooseProperty.type = toMongooseType(type);
+
+        if (name === '_id' && properties[name] === false) {
+          mongooseProperty.type = false;
+        }
+        else {
+          mongooseProperty.type = toMongooseType(type);
+        }
+
         copyOtherMongooseAttributes(property,mongooseProperty);
         break;
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@exalif/generator-feathers-plus",
   "description": "A Yeoman generator to (re)generate a FeathersJS application supporting both REST and GraphQL architectural concepts and their query languages.",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "homepage": "https://github.com/exalif/generator-feathers-plus",
   "main": "lib/",
   "keywords": [

--- a/test-expands/ts-cumulative-1-mongoose.test-copy/src1/services/users-1/users-1.schema.js
+++ b/test-expands/ts-cumulative-1-mongoose.test-copy/src1/services/users-1/users-1.schema.js
@@ -23,7 +23,18 @@ let schema = {
   // Fields in the model.
   properties: {
     // !code: schema_properties
-    name: {}
+    name: {},
+    members: {
+      type: 'array',
+      uniqueItems: true,
+      items: {
+        type: 'object',
+        properties: {
+          _id: false,
+          rule: { type: 'string' }
+        }
+      }
+    },
     // !end
   },
   // !code: schema_more // !end

--- a/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/users-1/users-1.interface.ts
+++ b/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/users-1/users-1.interface.ts
@@ -7,6 +7,7 @@
 export interface Users1Base {
   // !<DEFAULT> code: interface
   name: string;
+  members: any[];
   // !end
 }
 

--- a/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/users-1/users-1.mongo.ts
+++ b/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/users-1/users-1.mongo.ts
@@ -16,6 +16,19 @@ let moduleExports = merge({},
       },
       name: {
         bsonType: "string"
+      },
+      members: {
+        uniqueItems: true,
+        items: {
+          type: "object",
+          properties: {
+            _id: false,
+            rule: {
+              type: "string"
+            }
+          }
+        },
+        bsonType: "array"
       }
     }
   },

--- a/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/users-1/users-1.mongoose.ts
+++ b/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/users-1/users-1.mongoose.ts
@@ -10,7 +10,13 @@ import mongoose from 'mongoose';
 let moduleExports = merge({},
   // !<DEFAULT> code: model
   {
-    name: String
+    name: String,
+    members: [
+      {
+        _id: false,
+        rule: String
+      }
+    ]
   },
   // !end
   // !code: moduleExports // !end

--- a/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/users-1/users-1.schema.ts
+++ b/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/users-1/users-1.schema.ts
@@ -23,7 +23,18 @@ let schema = {
   // Fields in the model.
   properties: {
     // !code: schema_properties
-    name: {}
+    name: {},
+    members: {
+      type: 'array',
+      uniqueItems: true,
+      items: {
+        type: 'object',
+        properties: {
+          _id: false,
+          rule: { type: 'string' }
+        }
+      }
+    },
     // !end
   },
   // !code: schema_more // !end

--- a/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/users-1/users-1.sequelize.ts
+++ b/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/users-1/users-1.sequelize.ts
@@ -20,6 +20,9 @@ let moduleExports = merge({},
   {
     name: {
       type: DataTypes.TEXT
+    },
+    members: {
+      type: DataTypes.JSONB
     }
   } as DefineAttributes,
   // !end

--- a/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/users-1/users-1.validate.ts
+++ b/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/users-1/users-1.validate.ts
@@ -22,6 +22,19 @@ let base = merge({},
     properties: {
       name: {
         type: "string"
+      },
+      members: {
+        type: "array",
+        uniqueItems: true,
+        items: {
+          type: "object",
+          properties: {
+            _id: false,
+            rule: {
+              type: "string"
+            }
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
### Summary

Add support for `_id: false` in schema to prevent `_id` to be added by mongoose automatically.

See there:
https://stackoverflow.com/questions/17254008/stop-mongoose-from-creating-id-property-for-sub-document-array-items